### PR TITLE
Fix: ts-node-dev에서 .d.ts 에 선언된 타입을 읽지 못하는 문제 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.2.1",
         "husky": "^8.0.1",
-        "ts-node-dev": "^2.0.0",
+        "ts-node-dev": "^1.1.8",
         "tsconfig-paths": "^4.1.0"
       }
     },
@@ -4444,20 +4444,20 @@
       }
     },
     "node_modules/ts-node-dev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
-      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
+      "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.1",
         "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.5",
         "mkdirp": "^1.0.4",
         "resolve": "^1.0.0",
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
         "tree-kill": "^1.2.2",
-        "ts-node": "^10.4.0",
+        "ts-node": "^9.0.0",
         "tsconfig": "^7.0.0"
       },
       "bin": {
@@ -4487,6 +4487,32 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ts-node-dev/node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
       }
     },
     "node_modules/tsconfig": {
@@ -8138,20 +8164,20 @@
       }
     },
     "ts-node-dev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
-      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
+      "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
       "dev": true,
       "requires": {
         "chokidar": "^3.5.1",
         "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.5",
         "mkdirp": "^1.0.4",
         "resolve": "^1.0.0",
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
         "tree-kill": "^1.2.2",
-        "ts-node": "^10.4.0",
+        "ts-node": "^9.0.0",
         "tsconfig": "^7.0.0"
       },
       "dependencies": {
@@ -8162,6 +8188,20 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
+          }
+        },
+        "ts-node": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+          "dev": true,
+          "requires": {
+            "arg": "^4.1.0",
+            "create-require": "^1.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.17",
+            "yn": "3.1.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
     "husky": "^8.0.1",
-    "ts-node-dev": "^2.0.0",
+    "ts-node-dev": "^1.1.8",
     "tsconfig-paths": "^4.1.0"
   }
 }


### PR DESCRIPTION
## What is this PR?

개발 서버에서 .d.ts 파일에 선언한 타입을 읽지 못하는 문제 수정함.

- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Changes

- ts-node-dev 패키지 버전 2.0.0 → 1.1.8 변경

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] 같은 코드로 nodemon에서 실행 후, 타입 오류 없음 확인
- [x] 같은 패키지의 이전 버전(1.1.8)을 사용한 프로젝트에서 타입 오류가 없는 것 확인.
버전을 2.0.0으로 올릴 경우, 타입 오류가 발생함.

## Etc

해결에 참조한 이슈와 그에 관한 생각들.

- [issue 1](https://github.com/wclr/ts-node-dev/issues/169): 가장 처음엔 이 사례를 참조하여 해결 자체는 함.

- 그러나 [issue 2](https://github.com/TypeStrong/ts-node/issues/1132#issuecomment-714582153)를 통해, `tsc --showConfig` 를 실행한 결과, .d.ts 파일이 files 배열에 들어가 있는 것을 확인할 수 있음.

결과적으로, `--files` 옵션은 tsconfig file에 포함할 파일을 추가하는 것인데, 이 옵션을 추가하지 않더라도 files 배열에서 확인이 되므로 .d.ts 파일을 불러오지 못해 발생하는 이슈가 아니라는 것을 알 수 있음.

resolve #8 