### PR TITLE
Refactor: disable team model timestamps

### DIFF
--- a/src/models/team.ts
+++ b/src/models/team.ts
@@ -13,8 +13,6 @@ export default class Team extends Model<
 > {
   declare id: CreationOptional<number>;
   declare team: string;
-  declare createdAt: CreationOptional<Date>;
-  declare updatedAt: CreationOptional<Date>;
 
   static initialize(sequelize: Sequelize) {
     return Team.init(
@@ -28,12 +26,11 @@ export default class Team extends Model<
           type: DataTypes.STRING,
           allowNull: false,
         },
-        createdAt: DataTypes.DATE,
-        updatedAt: DataTypes.DATE,
       },
       {
         sequelize,
         charset: 'utf8',
+        timestamps: false,
       }
     );
   }

--- a/src/routes/teams/team.controller.ts
+++ b/src/routes/teams/team.controller.ts
@@ -9,8 +9,7 @@ export const getMyTeams: express.RequestHandler = async (req, res) => {
   try {
     if (req.user) {
       const teams = await req.user.getTeams();
-      const teamsInfo = teams.map(team => ({ id: team.id, team: team.team }));
-      res.json(teamsInfo);
+      res.json(teams);
     }
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## What is this PR?

model column 변경

## Changes

- 사용하지 않는 createdAt, updatedAt 칼럼 비활성화
- getMyTeams 라우터 로직에서 timestamp와 관련된 칼럼 제외하는 순회 코드 삭제

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

없음

## Etc

없음
