### PR TITLE
Feat: my teams 리스트 요청 및 변경에 팀 선호도 값 제어 로직 추가

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -2,6 +2,7 @@ import { Sequelize } from 'sequelize';
 import { dbConfig } from '@config';
 import { ENV } from '@typings/db';
 import Team from './team';
+import Team_Fans from './team_fans';
 import User from './user';
 
 const env = (process.env.NODE_ENV as ENV) || 'development';
@@ -16,8 +17,9 @@ const sequelize = new Sequelize(
 
 User.initialize(sequelize);
 Team.initialize(sequelize);
+Team_Fans.initialize(sequelize);
 
-User.belongsToMany(Team, { through: 'TeamFans' });
-Team.belongsToMany(User, { through: 'TeamFans', as: 'Fans' });
+User.belongsToMany(Team, { through: 'Team_Fans' });
+Team.belongsToMany(User, { through: 'Team_Fans', as: 'Fans' });
 
 export { sequelize };

--- a/src/models/team.ts
+++ b/src/models/team.ts
@@ -4,8 +4,10 @@ import {
   InferAttributes,
   InferCreationAttributes,
   Model,
+  NonAttribute,
   Sequelize,
 } from 'sequelize';
+import Team_Fans from './team_fans';
 
 export default class Team extends Model<
   InferAttributes<Team>,
@@ -14,6 +16,7 @@ export default class Team extends Model<
   declare id: CreationOptional<number>;
   declare team: string;
   declare name: string;
+  declare Team_Fans: NonAttribute<Team_Fans>;
 
   static initialize(sequelize: Sequelize) {
     return Team.init(

--- a/src/models/team_fans.ts
+++ b/src/models/team_fans.ts
@@ -1,0 +1,30 @@
+import {
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+  Sequelize,
+} from 'sequelize';
+
+export default class Team_Fans extends Model<
+  InferAttributes<Team_Fans>,
+  InferCreationAttributes<Team_Fans>
+> {
+  declare preference: number;
+
+  static initialize(sequelize: Sequelize) {
+    return Team_Fans.init(
+      {
+        preference: {
+          type: DataTypes.INTEGER.UNSIGNED,
+          allowNull: false,
+        },
+      },
+      {
+        sequelize,
+        charset: 'utf8',
+        timestamps: false,
+      }
+    );
+  }
+}

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -8,6 +8,7 @@ import {
   InferAttributes,
   InferCreationAttributes,
   Model,
+  NonAttribute,
   Sequelize,
 } from 'sequelize';
 import Team from './team';
@@ -26,6 +27,7 @@ export default class User extends Model<
   declare addTeam: BelongsToManyAddAssociationMixin<Team, number>;
   declare removeTeam: BelongsToManyRemoveAssociationMixin<Team, number>;
   declare hasTeam: BelongsToManyHasAssociationMixin<Team, number>;
+  declare Teams: NonAttribute<Team[]>;
 
   static initialize(sequelize: Sequelize) {
     return User.init(

--- a/src/routes/teams/team.controller.ts
+++ b/src/routes/teams/team.controller.ts
@@ -9,7 +9,21 @@ export const getMyTeams: express.RequestHandler = async (req, res) => {
   try {
     if (req.user) {
       const teams = await req.user.getTeams();
-      res.json(teams);
+      const teamPreference = teams.reduce<{ [team: string]: number }>(
+        (prev, curr) => {
+          return {
+            ...prev,
+            [curr.team]: curr.Team_Fans.preference,
+          };
+        },
+        {}
+      );
+
+      const teamsSortedByPreference = teams.sort(
+        (a, b) => teamPreference[a.team] - teamPreference[b.team]
+      );
+
+      res.json(teamsSortedByPreference);
     }
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## What is this PR?

close #30 

- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Changes

- user-team through table에 preference column 추가
- 팀 변경 요청시, 기존 로직에 선호도 값 로직만 추가 후, 전체 로직은 병렬 처리.
 ex) 남아있는 기존 팀인데 선호도가 변경된 경우, 새로운 팀인 경우 선호도 값도 함께 추가
- 팀 리스트 요청시, 선호도 값 순서대로 정렬하여 응답 처리해줌.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] 변경된 api router로 요청시, 로컬 db에 정확하게 데이터 요청, 수정 및 삭제가 발생하는지 확인 

## Etc

팀 변경시, 새 팀과 새 팀에 남아있는 기존 팀의 로직을 같은 단위에서 처리하고 싶었으나,
기존 팀의 선호도 값을 갖고 올 수 있는 방법을 생각해낼 수 없어
존재하지 않는 기존 팀, 남아있는 기존 팀, 새로운 팀 → 총 3가지로 나눠, 병렬 처리함.
