### PR TITLE
Fix: db 연결시 테이블명이 복수형으로 제대로 생성되지 않아 tableName 별도 부여

### DIFF
--- a/src/models/stadium.ts
+++ b/src/models/stadium.ts
@@ -32,6 +32,7 @@ export default class Stadium extends Model<
       },
       {
         sequelize,
+        tableName: 'stadiums',
         timestamps: false,
         charset: 'utf8',
       }


### PR DESCRIPTION
## What is this PR?

close #38 

## Changes

.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] db 테이블에 `stadiums`로 생성되는 것 확인

## Etc

없음
