### PR TITLE
Feat(association): Ticket, Season, Series, Season model db 연결 및 관계 추가

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,8 +1,12 @@
 import { Sequelize } from 'sequelize';
 import { dbConfig } from '@config';
 import { ENV } from '@typings/db';
+import Season from './season';
+import Series from './series';
+import Stadium from './stadium';
 import Team from './team';
 import Team_Fans from './team_fans';
+import Ticket from './ticket';
 import User from './user';
 
 const env = (process.env.NODE_ENV as ENV) || 'development';
@@ -18,8 +22,30 @@ const sequelize = new Sequelize(
 User.initialize(sequelize);
 Team.initialize(sequelize);
 Team_Fans.initialize(sequelize);
+Season.initialize(sequelize);
+Series.initialize(sequelize);
+Stadium.initialize(sequelize);
+Ticket.initialize(sequelize);
 
 User.belongsToMany(Team, { through: 'Team_Fans' });
 Team.belongsToMany(User, { through: 'Team_Fans', as: 'Fans' });
+
+Season.hasMany(Series);
+Series.belongsTo(Season);
+
+Team.hasMany(Stadium);
+Stadium.belongsTo(Team);
+
+User.hasMany(Ticket);
+Ticket.belongsTo(User);
+
+Season.hasMany(Ticket);
+Ticket.belongsTo(Season);
+
+Series.hasMany(Ticket);
+Ticket.belongsTo(Series);
+
+Stadium.hasMany(Ticket);
+Ticket.belongsTo(Stadium);
 
 export { sequelize };

--- a/src/models/ticket.ts
+++ b/src/models/ticket.ts
@@ -7,6 +7,9 @@ import {
   Model,
   Sequelize,
 } from 'sequelize';
+import Season from './season';
+import Series from './series';
+import Stadium from './stadium';
 import User from './user';
 
 export default class Ticket extends Model<
@@ -23,6 +26,9 @@ export default class Ticket extends Model<
   declare myTeam: string;
   declare opponentTeam: string;
   declare UserId: ForeignKey<User['id']>;
+  declare SeasonId: ForeignKey<Season['id']>;
+  declare SeriesId: ForeignKey<Series['id']>;
+  declare StadiumId: ForeignKey<Stadium['id']>;
 
   static initialize(sequelize: Sequelize) {
     return Ticket.init(


### PR DESCRIPTION
## What is this PR?

close #37 

## Changes

- 티켓은 특정 구장, 특정 시즌, 특정 유저에 속하므로 일대다 관계를 설정함.

- 팀과 구장 정보는 일대다 관계로 설정되어 있지만, 현재 초기 주입 데이터는 일대일 관계임.
(실제로 몇몇 구단은 일년에 2-3번 다른 구장을 홈구장으로 하여 경기하는데,
지금은 여러 개의 홈구장을 다루는 것이 어려울 것 같아 나중에 추가할 예정)

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] 테이블명 복수형으로 제대로 생성되는지 확인
- [x] 정의한 model column 생성 확인 

## Etc

없음
