### PR TITLE
Feat(route): 티켓 등록, 조회 api routes 추가

### DIFF
--- a/src/models/season.ts
+++ b/src/models/season.ts
@@ -1,11 +1,13 @@
 import {
   CreationOptional,
   DataTypes,
+  HasManyAddAssociationMixin,
   InferAttributes,
   InferCreationAttributes,
   Model,
   Sequelize,
 } from 'sequelize';
+import Ticket from './ticket';
 
 export default class Season extends Model<
   InferAttributes<Season>,
@@ -13,6 +15,7 @@ export default class Season extends Model<
 > {
   declare id: CreationOptional<number>;
   declare season: string;
+  declare addTicket: HasManyAddAssociationMixin<Ticket, number>;
 
   static initialize(sequelize: Sequelize) {
     return Season.init(

--- a/src/models/series.ts
+++ b/src/models/series.ts
@@ -2,12 +2,14 @@ import {
   CreationOptional,
   DataTypes,
   ForeignKey,
+  HasManyAddAssociationMixin,
   InferAttributes,
   InferCreationAttributes,
   Model,
   Sequelize,
 } from 'sequelize';
 import Season from './season';
+import Ticket from './ticket';
 
 export default class Series extends Model<
   InferAttributes<Series>,
@@ -16,6 +18,7 @@ export default class Series extends Model<
   declare id: CreationOptional<number>;
   declare series: string;
   declare SeasonId: ForeignKey<Season['id']>;
+  declare addTicket: HasManyAddAssociationMixin<Ticket, number>;
 
   static initialize(sequelize: Sequelize) {
     return Series.init(

--- a/src/models/stadium.ts
+++ b/src/models/stadium.ts
@@ -2,12 +2,14 @@ import {
   CreationOptional,
   DataTypes,
   ForeignKey,
+  HasManyAddAssociationMixin,
   InferAttributes,
   InferCreationAttributes,
   Model,
   Sequelize,
 } from 'sequelize';
 import Team from './team';
+import Ticket from './ticket';
 
 export default class Stadium extends Model<
   InferAttributes<Stadium>,
@@ -16,6 +18,7 @@ export default class Stadium extends Model<
   declare id: CreationOptional<number>;
   declare stadium: string;
   declare TeamId: ForeignKey<Team['id']>;
+  declare addTicket: HasManyAddAssociationMixin<Ticket, number>;
 
   static initialize(sequelize: Sequelize) {
     return Stadium.init(

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -5,6 +5,7 @@ import {
   BelongsToManyRemoveAssociationMixin,
   CreationOptional,
   DataTypes,
+  HasManyAddAssociationMixin,
   InferAttributes,
   InferCreationAttributes,
   Model,
@@ -12,6 +13,7 @@ import {
   Sequelize,
 } from 'sequelize';
 import Team from './team';
+import Ticket from './ticket';
 
 export default class User extends Model<
   InferAttributes<User>,
@@ -28,6 +30,7 @@ export default class User extends Model<
   declare removeTeam: BelongsToManyRemoveAssociationMixin<Team, number>;
   declare hasTeam: BelongsToManyHasAssociationMixin<Team, number>;
   declare Teams: NonAttribute<Team[]>;
+  declare addTicket: HasManyAddAssociationMixin<Ticket, number>;
 
   static initialize(sequelize: Sequelize) {
     return User.init(

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,10 +1,12 @@
 import { Router } from 'express';
 import authRouter from './auth';
 import teamsRouter from './teams';
+import ticketsRouter from './tickets';
 
 const router = Router();
 
 router.use('/auth', authRouter);
 router.use('/teams', teamsRouter);
+router.use('/tickets', ticketsRouter);
 
 export default router;

--- a/src/routes/tickets/index.ts
+++ b/src/routes/tickets/index.ts
@@ -1,0 +1,9 @@
+import * as express from 'express';
+import { isLoggedIn } from '@middlewares';
+import * as controller from './tickets.controller';
+
+const router = express.Router();
+
+router.post('/', isLoggedIn, controller.createTicket);
+
+export default router;

--- a/src/routes/tickets/index.ts
+++ b/src/routes/tickets/index.ts
@@ -5,5 +5,6 @@ import * as controller from './tickets.controller';
 const router = express.Router();
 
 router.post('/', isLoggedIn, controller.createTicket);
+router.get('/my', isLoggedIn, controller.getMyTickets);
 
 export default router;

--- a/src/routes/tickets/tickets.controller.ts
+++ b/src/routes/tickets/tickets.controller.ts
@@ -1,0 +1,63 @@
+import * as express from 'express';
+import { db } from '@models';
+
+interface TypedExpressRequest<T> extends express.Request {
+  body: T;
+}
+
+interface TicketBody {
+  matchDate: string;
+  matchSeason: string;
+  matchSeries: string;
+  homeTeam: string;
+  awayTeam: string;
+  score: {
+    homeTeam: number;
+    awayTeam: number;
+  };
+  scoreType: string;
+  myTeam: string;
+  opponentTeam: string;
+  stadium: string;
+}
+
+export const createTicket: express.RequestHandler = async (
+  req: TypedExpressRequest<TicketBody>,
+  res
+) => {
+  try {
+    const season = await db.Season.findOne({
+      where: { season: req.body.matchSeason },
+    });
+    const series = await db.Series.findOne({
+      where: { series: req.body.matchSeries },
+    });
+    const stadium = await db.Stadium.findOne({
+      where: { stadium: req.body.stadium },
+    });
+
+    if (req.user) {
+      const ticket = await db.Ticket.create({
+        date: req.body.matchDate,
+        homeTeam: req.body.homeTeam,
+        awayTeam: req.body.awayTeam,
+        myTeam: req.body.myTeam,
+        opponentTeam: req.body.opponentTeam,
+        scoreType: req.body.scoreType,
+        homeTeamScore: req.body.score.homeTeam,
+        awayTeamScore: req.body.score.awayTeam,
+      });
+
+      const addTicketAssociation = [
+        req.user.addTicket(ticket),
+        season && season.addTicket(ticket),
+        series && series.addTicket(ticket),
+        stadium && stadium.addTicket(ticket),
+      ];
+      await Promise.all(addTicketAssociation);
+      res.send({ ...ticket, series, season, stadium });
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/routes/tickets/tickets.controller.ts
+++ b/src/routes/tickets/tickets.controller.ts
@@ -61,3 +61,22 @@ export const createTicket: express.RequestHandler = async (
     console.error(error);
   }
 };
+
+export const getMyTickets: express.RequestHandler = async (req, res) => {
+  try {
+    if (req.user) {
+      const tickets = await db.Ticket.findAll({
+        where: { UserId: req.user.id },
+        include: [
+          { model: db.Season },
+          { model: db.Series },
+          { model: db.Stadium },
+        ],
+      });
+
+      res.send(tickets);
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};


### PR DESCRIPTION
## What is this PR?

close #44 

## Changes

- 사용자의 티켓만 조회하므로, `my` 경로를 붙여줌.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] 티켓 등록 api 호출시, 올바르게 body 객체 값이 전송되고, db에 잘 저장되는지 확인
- [x] 티켓 조회 api 호출 정상 응답 확인

## Etc

티켓 조회시 데이터 정렬에 대해서는 추후 추가할 예정.
