### PR TITLE
Fix(model): Ticket model date column type string to Date

### DIFF
--- a/src/models/ticket.ts
+++ b/src/models/ticket.ts
@@ -41,12 +41,6 @@ export default class Ticket extends Model<
         date: {
           type: DataTypes.DATEONLY,
           allowNull: false,
-          set(value: { year: number; month: number; date: number }) {
-            this.setDataValue(
-              'date',
-              new Date(value.year, value.month - 1, value.date)
-            );
-          },
         },
         homeTeam: {
           type: DataTypes.STRING,

--- a/src/models/ticket.ts
+++ b/src/models/ticket.ts
@@ -17,7 +17,7 @@ export default class Ticket extends Model<
   InferCreationAttributes<Ticket>
 > {
   declare id: CreationOptional<number>;
-  declare date: string;
+  declare date: Date;
   declare homeTeam: string;
   declare awayTeam: string;
   declare homeTeamScore: number;
@@ -39,8 +39,14 @@ export default class Ticket extends Model<
           primaryKey: true,
         },
         date: {
-          type: DataTypes.STRING,
+          type: DataTypes.DATEONLY,
           allowNull: false,
+          set(value: { year: number; month: number; date: number }) {
+            this.setDataValue(
+              'date',
+              new Date(value.year, value.month - 1, value.date)
+            );
+          },
         },
         homeTeam: {
           type: DataTypes.STRING,

--- a/src/routes/tickets/tickets.controller.ts
+++ b/src/routes/tickets/tickets.controller.ts
@@ -6,7 +6,11 @@ interface TypedExpressRequest<T> extends express.Request {
 }
 
 interface TicketBody {
-  matchDate: string;
+  matchDate: {
+    year: number;
+    month: number;
+    date: number;
+  };
   matchSeason: string;
   matchSeries: string;
   homeTeam: string;

--- a/src/routes/tickets/tickets.controller.ts
+++ b/src/routes/tickets/tickets.controller.ts
@@ -42,7 +42,11 @@ export const createTicket: express.RequestHandler = async (
 
     if (req.user) {
       const ticket = await db.Ticket.create({
-        date: req.body.matchDate,
+        date: new Date(
+          req.body.matchDate.year,
+          req.body.matchDate.month - 1,
+          req.body.matchDate.date
+        ),
         homeTeam: req.body.homeTeam,
         awayTeam: req.body.awayTeam,
         myTeam: req.body.myTeam,


### PR DESCRIPTION
## What is this PR?

close #33 

## Changes

날짜순으로 정렬이 가능한 `Date` 타입으로 변경하되,
시간을 제외한 날짜만 지정 가능하도록 `DATEONLY` 타입을 칼럼의 형태로 지정함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] 객체 형태로 `{ year: 2022, month: 10, date: 16 }` 과 같은 날짜 데이터를 받을 때, db에 `2022-10-16` 형태로 데이터 저장 확인

## Etc

이제 프론트에서 날짜 데이터를 전달할 때, 가공이 필요하지 않음.
