### PR TITLE
Refactor(model): opponentTeam attributes to virtual field

### DIFF
--- a/src/models/ticket.ts
+++ b/src/models/ticket.ts
@@ -24,7 +24,7 @@ export default class Ticket extends Model<
   declare awayTeamScore: number;
   declare scoreType: string;
   declare myTeam: string;
-  declare opponentTeam: string;
+  declare opponentTeam: string | null;
   declare UserId: ForeignKey<User['id']>;
   declare SeasonId: ForeignKey<Season['id']>;
   declare SeriesId: ForeignKey<Series['id']>;
@@ -67,8 +67,13 @@ export default class Ticket extends Model<
           allowNull: false,
         },
         opponentTeam: {
-          type: DataTypes.STRING,
-          allowNull: false,
+          type: DataTypes.VIRTUAL,
+          get() {
+            return this.homeTeam == this.myTeam ? this.awayTeam : this.homeTeam;
+          },
+          set() {
+            throw new Error('Do not set the `opponentTeam` value');
+          },
         },
       },
       {

--- a/src/routes/tickets/tickets.controller.ts
+++ b/src/routes/tickets/tickets.controller.ts
@@ -21,7 +21,6 @@ interface TicketBody {
   };
   scoreType: string;
   myTeam: string;
-  opponentTeam: string;
   stadium: string;
 }
 
@@ -50,7 +49,6 @@ export const createTicket: express.RequestHandler = async (
         homeTeam: req.body.homeTeam,
         awayTeam: req.body.awayTeam,
         myTeam: req.body.myTeam,
-        opponentTeam: req.body.opponentTeam,
         scoreType: req.body.scoreType,
         homeTeamScore: req.body.score.homeTeam,
         awayTeamScore: req.body.score.awayTeam,


### PR DESCRIPTION
## What is this PR?

close #33 

## Changes

나의 응원팀에 반대되는 팀 정보를 db 칼럼으로 지정하지 않고,
그 외 지정된 column 값(homeTeam, awayTeam, myTeam)을 이용하여 getter로 가져오도록 변경함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] db에 `opponentTeam` 컬럼 생성되지 않음 확인
- ~~티켓 등록시, `opponentTeam` 값이 필수 요구되지 않음 확인~~
- ~~티켓 조회 api 실행시, `opponentTeam` 에 대한 정보 잘 가져옴.~~

## Etc

sequelize 공식문서에 virtual field에 대한 타입 설정에 대해 정확히 적혀 있지 않아, 타입 지정에 어려움이 있었음.

1. `NonAttribute<T>`
이 타입은 attribute가 존재하면 안되기 때문에, getter 함수를 지정할 수 없음.
attribute를 선언하는 대신, getter 함수를 설정할 수도 있지만 이 방법은 model instance에서 별도로 호출해야 함. 

2. `string | null`
attribute에 null 값을 허용하여, model instance 생성시 값이 필수 요구되지 않도록 함.
attribute의 데이터 타입을 `virtual` 로 지정했기 때문에, db에 컬럼이 생성되지 않으며, 값도 저장되지 않음.
getter 함수를 지정하여, model instance를 가져올 때 attribute 값을 함께 가져올 수 있음.