### PR TITLE
Fix(model): change virtual attribute type

### DIFF
--- a/src/models/ticket.ts
+++ b/src/models/ticket.ts
@@ -67,9 +67,15 @@ export default class Ticket extends Model<
           allowNull: false,
         },
         opponentTeam: {
-          type: DataTypes.VIRTUAL,
+          type: new DataTypes.VIRTUAL(DataTypes.STRING, [
+            'homeTeam',
+            'awayTeam',
+            'myTeam',
+          ]),
           get() {
-            return this.homeTeam == this.myTeam ? this.awayTeam : this.homeTeam;
+            return this.get('homeTeam') == this.get('myTeam')
+              ? this.get('awayTeam')
+              : this.get('homeTeam');
           },
           set() {
             throw new Error('Do not set the `opponentTeam` value');


### PR DESCRIPTION
## What is this PR?

close #33 

## Changes

### 문제가 발생한 코드 (pull_request #47)
model instance 생성시, opponentTeam 값을 주입하지 않음.
https://github.com/eenaree/my-ticket-server/blob/e95a588376b1d1c54aabdb9d321b7788ca0bdd00/src/routes/tickets/tickets.controller.ts#L43-L55

직접 정의한 setter 함수는 값을 설정할 수 없다는 에러를 리턴하므로 티켓 등록이 실행될 수 없음.
https://github.com/eenaree/my-ticket-server/blob/e95a588376b1d1c54aabdb9d321b7788ca0bdd00/src/models/ticket.ts#L74-L76

### 해결 1.

이 코드를 보완하려면, 인스턴스 생성시 opponentTeam 값을 주입하는 코드를 추가하면 됨.
getter 함수에서 지정했던 코드를 인스턴스 생성 코드에서 알맞게 변경하면 됨.
https://github.com/eenaree/my-ticket-server/blob/e95a588376b1d1c54aabdb9d321b7788ca0bdd00/src/models/ticket.ts#L71-L73

```typescript
oppponentTeam: req.body.homeTeam == req.body.myTeam ? req.body.awayTeam ? req.body.homeTeam;
```

주입한 이후, virtual attribtue의 setter 함수를 재정의하면 오류를 해결할 수 있음.
```typescript
set(value: string) {
  return this.setDataValue('opponentTeam', value);
}
```
getter 함수와 opponentTeam 주입 코드가 중복되는 부분이 존재함.

### 해결 2.

opponentTeam 값은 모델 인스턴스를 조회할 때만 필요한 정보이므로, setter 함수를 정의하는 것은 다소 불필요함.
기존에 에러를 리턴하도록 하는 setter 함수를 유지하기 위해, `new` 생성자를 추가한 데이터 타입으로 변경함.

티켓 등록 시, opponentTeam field가 생성되지만, 실제 db에는 저장되지 않음. 값은 setter가 없으니, null일 것으로 추정됨.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] 티켓 등록시, 모델 인스턴스 생성 확인
- [x] 티켓 조회시, virtual attribute opponentTeam 정보 가져오는 것 확인

## Etc

위의 내용은 아래 문서를 참고하여 개선함.
https://github.com/sequelize/sequelize/blob/cf03c9859f3cb0aaa0e772821c80d1943129df92/src/data-types.js#L751-L790