### PR TITLE
Feat: implement getMyTickets route pagination

### DIFF
--- a/src/routes/tickets/tickets.controller.ts
+++ b/src/routes/tickets/tickets.controller.ts
@@ -68,7 +68,13 @@ export const getMyTickets: express.RequestHandler = async (req, res) => {
     if (req.user) {
       const tickets = await db.Ticket.findAll({
         where: { UserId: req.user.id },
-        include: [{ model: db.Season }, { model: db.Stadium }],
+        attributes: {
+          exclude: ['UserId', 'StadiumId'],
+        },
+        include: [
+          { model: db.Season, through: { attributes: [] } },
+          { model: db.Stadium },
+        ],
       });
 
       res.send(tickets);

--- a/src/routes/tickets/tickets.controller.ts
+++ b/src/routes/tickets/tickets.controller.ts
@@ -1,6 +1,9 @@
 import * as express from 'express';
+import { InferAttributes, Op, WhereOptions } from 'sequelize';
 import { db } from '@models';
 import Season from '@models/season';
+import Ticket from '@models/ticket';
+import { TypedExpressQuery } from '@typings/db';
 
 interface TypedExpressRequest<T> extends express.Request {
   body: T;
@@ -63,11 +66,36 @@ export const createTicket: express.RequestHandler = async (
   }
 };
 
-export const getMyTickets: express.RequestHandler = async (req, res) => {
+export const getMyTickets = async (
+  req: TypedExpressQuery<{ lastDate?: string; lastId?: string }>,
+  res: express.Response<Ticket[]>
+) => {
   try {
     if (req.user) {
+      let whereClause: WhereOptions<InferAttributes<Ticket>> = {
+        UserId: req.user.id,
+      };
+      if (req.query.lastDate && req.query.lastId) {
+        whereClause = {
+          UserId: req.user.id,
+          [Op.or]: [
+            {
+              date: {
+                [Op.lt]: new Date(req.query.lastDate), // lastDate 이전 날짜 티켓
+              },
+            },
+            {
+              [Op.and]: [
+                { date: { [Op.eq]: new Date(req.query.lastDate) } },
+                { id: { [Op.gt]: req.query.lastId } }, // lastDate 와 동일한 날짜의 티켓이면서 가져오지 않은 티켓
+              ],
+            },
+          ],
+        };
+      }
+
       const tickets = await db.Ticket.findAll({
-        where: { UserId: req.user.id },
+        where: whereClause,
         attributes: {
           exclude: ['UserId', 'StadiumId'],
         },
@@ -75,6 +103,8 @@ export const getMyTickets: express.RequestHandler = async (req, res) => {
           { model: db.Season, through: { attributes: [] } },
           { model: db.Stadium },
         ],
+        order: [['date', 'DESC']],
+        limit: 10,
       });
 
       res.send(tickets);

--- a/src/typings/db.ts
+++ b/src/typings/db.ts
@@ -1,1 +1,8 @@
+import * as express from 'express';
+import { ParsedQs } from 'qs';
+
 export type ENV = 'development' | 'test' | 'production';
+
+export interface TypedExpressQuery<T extends ParsedQs> extends express.Request {
+  query: T;
+}


### PR DESCRIPTION
## What is this PR?

close #44 

## Changes

첫번째 요청 시에만, `req.query` 객체 전달 없이 인스턴스를 불러오도록 하고,
이후 요청부터는 전달받은 `req.query.lastDate` 이전 날짜의 인스턴스 값을 계속 가져오도록 함.
단, 중복되는 날짜의 티켓이 n개 존재할 경우, 생략되는 티켓이 발생하는 경우가 생김.

예를 들어, `2021-05-04` 날짜의 티켓이 3개 존재할 경우,
이전 api 요청에서 해당 날짜의 티켓이 2개 전달되고,
나머지 1개가 남은 경우 이후 요청시 남은 1개의 티켓은 가져오지 못하는 문제가 발생하게 됨.

따라서, 요청시 마지막 티켓의 id 값으로 남은 1개의 티켓도 포함될 수 있도록 함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] `req.query.lastDate`, `req.query.lastId` 값 전달 여부에 따라 쿼리 결과 달라지는 것 확인.

## Etc

없음
