### PR TITLE
Refactor: error handling

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import * as morgan from 'morgan';
 import * as passport from 'passport';
 import { sequelize } from '~/models';
 import routes from '~/routes';
+import { errorHandler } from './lib/errorHandler';
 import { passportConfig } from './passport';
 
 dotenv.config();
@@ -23,6 +24,7 @@ app.set('port', process.env.PORT || 8080);
     console.log('db 연결 성공!');
   } catch (error) {
     console.error('db 연결 실패...');
+    console.error(error);
   }
 })();
 
@@ -49,16 +51,6 @@ app.use(passport.initialize());
 app.use(passport.session());
 
 app.use('/api', routes);
-
-const errorHandler: express.ErrorRequestHandler = (err, req, res, next) => {
-  if (err instanceof Error) {
-    if (res.headersSent) {
-      return next(err);
-    }
-    console.error(err.stack);
-    res.status(500).send({ message: '서버 오류가 발생했습니다.' });
-  }
-};
 
 app.use(errorHandler);
 

--- a/src/lib/AppError.ts
+++ b/src/lib/AppError.ts
@@ -1,0 +1,39 @@
+export class AppError extends Error {
+  statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = this.constructor.name;
+    this.statusCode = statusCode;
+  }
+}
+
+export class UnknownError extends AppError {
+  constructor(message = 'Unknown error', statusCode = 500) {
+    super(message, statusCode);
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message = 'Unauthorized', statusCode = 401) {
+    super(message, statusCode);
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = 'Forbidden', statusCode = 403) {
+    super(message, statusCode);
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = 'Resource not found', statusCode = 404) {
+    super(message, statusCode);
+  }
+}
+
+export class BadRequestError extends AppError {
+  constructor(message = 'Bad Request', statusCode = 400) {
+    super(message, statusCode);
+  }
+}

--- a/src/lib/errorHandler.ts
+++ b/src/lib/errorHandler.ts
@@ -1,0 +1,14 @@
+import * as express from 'express';
+import { AppError } from './AppError';
+
+export const errorHandler: express.ErrorRequestHandler = (err, req, res) => {
+  if (err instanceof AppError) {
+    return res
+      .status(err.statusCode)
+      .send({ name: err.name, status: err.statusCode, message: err.message });
+  }
+
+  res
+    .status(500)
+    .send({ name: 'UnknownError', status: 500, message: 'Unknown error' });
+};

--- a/src/middlewares/isLoggedIn.ts
+++ b/src/middlewares/isLoggedIn.ts
@@ -1,9 +1,10 @@
 import * as express from 'express';
+import { UnauthorizedError } from '~/lib/AppError';
 
 export const isLoggedIn: express.RequestHandler = (req, res, next) => {
   if (req.isAuthenticated()) {
     next();
   } else {
-    res.status(401).json({ success: false, message: '로그인이 필요합니다.' });
+    throw new UnauthorizedError();
   }
 };

--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import * as express from 'express';
 import * as passport from 'passport';
+import { NotFoundError, UnknownError } from '~/lib/AppError';
 
 const CLIENT_URL = 'http://localhost:4000';
 
@@ -20,19 +21,17 @@ export const naverAuthCallback = passport.authenticate('naver', {
 
 export const login: express.RequestHandler = (req, res) => {
   if (req.user) {
-    res.json({
-      success: true,
-      message: '사용자 인증이 성공적으로 처리됐습니다.',
-      user: req.user,
-    });
+    res.send(req.user);
+  } else {
+    throw new NotFoundError('User not found');
   }
 };
 
-export const logout: express.RequestHandler = (req, res, next) => {
+export const logout: express.RequestHandler = (req, res) => {
   req.logout(error => {
     if (error) {
-      return next(error);
+      throw new UnknownError();
     }
-    res.json({ success: true, message: '로그아웃 성공' });
+    res.send('로그아웃 성공');
   });
 };


### PR DESCRIPTION
## What is this PR?

에러 처리 방식 변경

## Changes

catch문에서 상태 코드와 메세지에 대해 일일이 처리하지 않고,
별도의 파일에서 관리하면서 추가 처리가 필요한 경우에만 확장할 수 있게 변경함.

로그아웃 처리는 콜백을 통해 비동기로 처리될 때, 에러가 발생할 수 있는 상황은
서버가 동작을 하지 않아 로그인이 풀렸거나, 애초에 로그인이 안된 상태에서 로그아웃 처리가 이뤄지는 경우라고 생각됨.
여기서 인증 에러를 던지는 것이 맞는 방법인진 잘 모르겠어서, `UnknownError` 를 던짐.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

없음

## Etc

없음