### PR TITLE
Refactor: prisma migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@prisma/client": "^4.5.0",
         "cors": "^2.8.5",
+        "dayjs": "^1.11.6",
         "dotenv": "^16.0.2",
         "express": "^4.18.1",
         "express-session": "^1.17.3",
@@ -1135,6 +1136,11 @@
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -5664,6 +5670,11 @@
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
       }
+    },
+    "dayjs": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@prisma/client": "^4.5.0",
         "cors": "^2.8.5",
         "dotenv": "^16.0.2",
         "express": "^4.18.1",
@@ -19,6 +20,7 @@
         "passport-google-oauth20": "^2.0.0",
         "passport-kakao": "^1.0.1",
         "passport-naver": "^1.0.6",
+        "prisma": "^4.5.0",
         "sequelize": "^6.25.3",
         "sequelize-cli": "^6.5.2",
         "ts-node": "^10.9.1",
@@ -205,6 +207,37 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
+    },
+    "node_modules/@prisma/client": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.5.0.tgz",
+      "integrity": "sha512-B2cV0OPI1smhdYUxsJoLYQLoMlLH06MUxgFUWQnHodGMX98VRVXKmQE/9OcrTNkqtke5RC+YU24Szxd04tZA2g==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines-version": "4.5.0-43.0362da9eebca54d94c8ef5edd3b2e90af99ba452"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/engines": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.5.0.tgz",
+      "integrity": "sha512-4t9ir2SbQQr/wMCNU4YpHWp5hU14J2m3wHUZnGJPpmBF8YtkisxyVyQsKd1e6FyLTaGq8LOLhm6VLYHKqKNm+g==",
+      "hasInstallScript": true
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "4.5.0-43.0362da9eebca54d94c8ef5edd3b2e90af99ba452",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.5.0-43.0362da9eebca54d94c8ef5edd3b2e90af99ba452.tgz",
+      "integrity": "sha512-o7LyVx8PPJBLrEzLl6lpxxk2D5VnlM4Fwmrbq0NoT6pr5aa1OuHD9ZG+WJY6TlR/iD9bhmo2LNcxddCMr5Rv2A=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -3620,6 +3653,22 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prisma": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.5.0.tgz",
+      "integrity": "sha512-9Aeg4qiKlv9Wsjz4NO8k2CzRzlvS3A4FYVJ5+28sBBZ0eEwbiVOE/Jj7v6rZC1tFW2s4GSICQOAyuOjc6WsNew==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines": "4.5.0"
+      },
+      "bin": {
+        "prisma": "build/index.js",
+        "prisma2": "build/index.js"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -4894,6 +4943,24 @@
           "dev": true
         }
       }
+    },
+    "@prisma/client": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.5.0.tgz",
+      "integrity": "sha512-B2cV0OPI1smhdYUxsJoLYQLoMlLH06MUxgFUWQnHodGMX98VRVXKmQE/9OcrTNkqtke5RC+YU24Szxd04tZA2g==",
+      "requires": {
+        "@prisma/engines-version": "4.5.0-43.0362da9eebca54d94c8ef5edd3b2e90af99ba452"
+      }
+    },
+    "@prisma/engines": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.5.0.tgz",
+      "integrity": "sha512-4t9ir2SbQQr/wMCNU4YpHWp5hU14J2m3wHUZnGJPpmBF8YtkisxyVyQsKd1e6FyLTaGq8LOLhm6VLYHKqKNm+g=="
+    },
+    "@prisma/engines-version": {
+      "version": "4.5.0-43.0362da9eebca54d94c8ef5edd3b2e90af99ba452",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.5.0-43.0362da9eebca54d94c8ef5edd3b2e90af99ba452.tgz",
+      "integrity": "sha512-o7LyVx8PPJBLrEzLl6lpxxk2D5VnlM4Fwmrbq0NoT6pr5aa1OuHD9ZG+WJY6TlR/iD9bhmo2LNcxddCMr5Rv2A=="
     },
     "@tsconfig/node10": {
       "version": "1.0.9",
@@ -7498,6 +7565,14 @@
       "dev": true,
       "requires": {
         "fast-diff": "^1.1.2"
+      }
+    },
+    "prisma": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.5.0.tgz",
+      "integrity": "sha512-9Aeg4qiKlv9Wsjz4NO8k2CzRzlvS3A4FYVJ5+28sBBZ0eEwbiVOE/Jj7v6rZC1tFW2s4GSICQOAyuOjc6WsNew==",
+      "requires": {
+        "@prisma/engines": "4.5.0"
       }
     },
     "proto-list": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "eenaree",
   "license": "ISC",
   "dependencies": {
+    "@prisma/client": "^4.5.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.2",
     "express": "^4.18.1",
@@ -23,6 +24,7 @@
     "passport-google-oauth20": "^2.0.0",
     "passport-kakao": "^1.0.1",
     "passport-naver": "^1.0.6",
+    "prisma": "^4.5.0",
     "sequelize": "^6.25.3",
     "sequelize-cli": "^6.5.2",
     "ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@prisma/client": "^4.5.0",
     "cors": "^2.8.5",
+    "dayjs": "^1.11.6",
     "dotenv": "^16.0.2",
     "express": "^4.18.1",
     "express-session": "^1.17.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "prepare": "husky install",
     "lint": "eslint --ext .ts src/ --fix && prettier --write **/*.ts"
   },
+  "prisma": {
+    "seed": "ts-node prisma/seed"
+  },
   "author": "eenaree",
   "license": "ISC",
   "dependencies": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,32 +20,32 @@ model SeasonTickets {
 }
 
 model Season {
-  id            Int             @id @default(autoincrement()) @db.UnsignedInt
-  season        String          @db.VarChar(255)
-  seasonTickets SeasonTickets[]
+  id      Int             @id @default(autoincrement()) @db.UnsignedInt
+  season  String          @unique @db.VarChar(255)
+  tickets SeasonTickets[]
 
   @@map("seasons")
 }
 
 model Stadium {
   id      Int      @id @default(autoincrement()) @db.UnsignedInt
-  stadium String   @db.VarChar(255)
+  stadium String   @unique @db.VarChar(255)
   tickets Ticket[]
 
   @@map("stadiums")
 }
 
 model Team {
-  id        Int         @id @default(autoincrement()) @db.UnsignedInt
-  team      String      @db.VarChar(255)
-  userTeams UserTeams[]
+  id    Int         @id @default(autoincrement()) @db.UnsignedInt
+  team  String      @unique @db.VarChar(255)
+  users UserTeams[]
 
   @@map("teams")
 }
 
 model Ticket {
   id            Int             @id @default(autoincrement()) @db.UnsignedInt
-  date          DateTime        @db.Date
+  date          String          @db.VarChar(255)
   homeTeam      String          @db.VarChar(255)
   awayTeam      String          @db.VarChar(255)
   homeTeamScore Int
@@ -56,7 +56,7 @@ model Ticket {
   stadiumId     Int?            @map("StadiumId") @db.UnsignedInt
   user          User?           @relation(fields: [userId], references: [id], map: "tickets_ibfk_1")
   stadium       Stadium?        @relation(fields: [stadiumId], references: [id], map: "tickets_ibfk_2")
-  seasonTickets SeasonTickets[]
+  seasons       SeasonTickets[]
 
   @@index([stadiumId], map: "StadiumId")
   @@index([userId], map: "UserId")
@@ -78,13 +78,13 @@ model UserTeams {
 
 model User {
   id        Int         @id @default(autoincrement()) @db.UnsignedInt
-  email     String      @db.VarChar(255)
+  email     String      @unique @db.VarChar(255)
   nickname  String      @db.VarChar(255)
   provider  String?     @db.VarChar(255)
   createdAt DateTime    @default(now())
   updatedAt DateTime    @updatedAt
   tickets   Ticket[]
-  userTeams UserTeams[]
+  myTeams   UserTeams[]
 
   @@map("users")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,90 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mysql"
+  url      = env("DATABASE_URL")
+}
+
+model SeasonTickets {
+  seasonId Int    @map("SeasonId") @db.UnsignedInt
+  ticketId Int    @map("TicketId") @db.UnsignedInt
+  season   Season @relation(fields: [seasonId], references: [id], onDelete: Cascade, map: "season_tickets_ibfk_1")
+  ticket   Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade, map: "season_tickets_ibfk_2")
+
+  @@id([seasonId, ticketId])
+  @@unique([seasonId, ticketId], map: "season_tickets_TicketId_SeasonId_unique")
+  @@index([ticketId], map: "TicketId")
+  @@map("season_tickets")
+}
+
+model Season {
+  id            Int             @id @default(autoincrement()) @db.UnsignedInt
+  season        String          @db.VarChar(255)
+  seasonTickets SeasonTickets[]
+
+  @@map("seasons")
+}
+
+model Stadium {
+  id      Int      @id @default(autoincrement()) @db.UnsignedInt
+  stadium String   @db.VarChar(255)
+  tickets Ticket[]
+
+  @@map("stadiums")
+}
+
+model Team {
+  id        Int         @id @default(autoincrement()) @db.UnsignedInt
+  team      String      @db.VarChar(255)
+  userTeams UserTeams[]
+
+  @@map("teams")
+}
+
+model Ticket {
+  id            Int             @id @default(autoincrement()) @db.UnsignedInt
+  date          DateTime        @db.Date
+  homeTeam      String          @db.VarChar(255)
+  awayTeam      String          @db.VarChar(255)
+  homeTeamScore Int
+  awayTeamScore Int
+  scoreType     String          @db.VarChar(255)
+  myTeam        String          @db.VarChar(255)
+  userId        Int?            @map("UserId") @db.UnsignedInt
+  stadiumId     Int?            @map("StadiumId") @db.UnsignedInt
+  user          User?           @relation(fields: [userId], references: [id], map: "tickets_ibfk_1")
+  stadium       Stadium?        @relation(fields: [stadiumId], references: [id], map: "tickets_ibfk_2")
+  seasonTickets SeasonTickets[]
+
+  @@index([stadiumId], map: "StadiumId")
+  @@index([userId], map: "UserId")
+  @@map("tickets")
+}
+
+model UserTeams {
+  preference Int  @db.UnsignedInt
+  userId     Int  @map("UserId") @db.UnsignedInt
+  teamId     Int  @map("TeamId") @db.UnsignedInt
+  user       User @relation(fields: [userId], references: [id], onDelete: Cascade, map: "user_teams_ibfk_1")
+  team       Team @relation(fields: [teamId], references: [id], onDelete: Cascade, map: "user_teams_ibfk_2")
+
+  @@id([userId, teamId])
+  @@unique([userId, teamId], map: "user_teams_TeamId_UserId_unique")
+  @@index([teamId], map: "TeamId")
+  @@map("user_teams")
+}
+
+model User {
+  id        Int         @id @default(autoincrement()) @db.UnsignedInt
+  email     String      @db.VarChar(255)
+  nickname  String      @db.VarChar(255)
+  provider  String?     @db.VarChar(255)
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
+  tickets   Ticket[]
+  userTeams UserTeams[]
+
+  @@map("users")
+}

--- a/prisma/seed/data/seasons.ts
+++ b/prisma/seed/data/seasons.ts
@@ -1,0 +1,10 @@
+import { Prisma } from '@prisma/client';
+
+export const seasons: Prisma.SeasonCreateInput[] = [
+  { season: '정규시즌' },
+  { season: '포스트시즌' },
+  { season: '와일드카드 결정전' },
+  { season: '준플레이오프' },
+  { season: '플레이오프' },
+  { season: '한국시리즈' },
+];

--- a/prisma/seed/data/stadiums.ts
+++ b/prisma/seed/data/stadiums.ts
@@ -1,0 +1,13 @@
+import { Prisma } from '@prisma/client';
+
+export const stadiums: Prisma.StadiumCreateInput[] = [
+  { stadium: '수원 KT 위즈 파크' },
+  { stadium: '잠실야구장' },
+  { stadium: '대구 삼성 라이온즈 파크' },
+  { stadium: '고척 스카이돔' },
+  { stadium: '인천 SSG 랜더스필드' },
+  { stadium: '사직야구장' },
+  { stadium: '창원 NC 파크' },
+  { stadium: '광주-기아 챔피언스 필드' },
+  { stadium: '대전 한화생명 이글스 파크' },
+];

--- a/prisma/seed/data/teams.ts
+++ b/prisma/seed/data/teams.ts
@@ -1,0 +1,14 @@
+import { Prisma } from '@prisma/client';
+
+export const teams: Prisma.TeamCreateInput[] = [
+  { team: 'KT' },
+  { team: 'OB' },
+  { team: 'SS' },
+  { team: 'LG' },
+  { team: 'WO' },
+  { team: 'SK' },
+  { team: 'LT' },
+  { team: 'NC' },
+  { team: 'HT' },
+  { team: 'HH' },
+];

--- a/prisma/seed/index.ts
+++ b/prisma/seed/index.ts
@@ -1,0 +1,20 @@
+import db from '~/db';
+import { seasons } from './data/seasons';
+import { stadiums } from './data/stadiums';
+import { teams } from './data/teams';
+
+async function seeding() {
+  await db.team.createMany({ data: teams });
+  await db.season.createMany({ data: seasons });
+  await db.stadium.createMany({ data: stadiums });
+}
+
+seeding()
+  .then(async () => {
+    await db.$disconnect();
+  })
+  .catch(async error => {
+    console.error(error);
+    await db.$disconnect();
+    process.exit(1);
+  });

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,6 @@ import * as express from 'express';
 import * as session from 'express-session';
 import * as morgan from 'morgan';
 import * as passport from 'passport';
-import { sequelize } from '~/models';
 import routes from '~/routes';
 import { errorHandler } from './lib/errorHandler';
 import { passportConfig } from './passport';
@@ -17,16 +16,6 @@ const app = express();
 const prod = process.env.NODE_ENV === 'production';
 
 app.set('port', process.env.PORT || 8080);
-
-(async function () {
-  try {
-    await sequelize.sync();
-    console.log('db 연결 성공!');
-  } catch (error) {
-    console.error('db 연결 실패...');
-    console.error(error);
-  }
-})();
 
 app.use(
   cors({

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,28 @@
+import { PrismaClient } from '@prisma/client';
+
+const db = new PrismaClient({
+  log: [
+    {
+      emit: 'event',
+      level: 'query',
+    },
+    {
+      emit: 'stdout',
+      level: 'error',
+    },
+    {
+      emit: 'stdout',
+      level: 'info',
+    },
+    {
+      emit: 'stdout',
+      level: 'warn',
+    },
+  ],
+});
+
+db.$on('query', e => {
+  console.log({ Query: e.query, Duration: e.duration });
+});
+
+export default db;

--- a/src/passport/index.ts
+++ b/src/passport/index.ts
@@ -1,5 +1,5 @@
 import * as passport from 'passport';
-import User from '~/models/user';
+import db from '~/db';
 import { googleStrategy } from './googleStrategy';
 import { kakaoStrategy } from './kakaoStrategy';
 import { naverStrategy } from './naverStrategy';
@@ -11,7 +11,7 @@ export function passportConfig() {
 
   passport.deserializeUser<number>(async (id, done) => {
     try {
-      const user = await User.findByPk(id);
+      const user = await db.user.findUnique({ where: { id } });
       if (!user) {
         done(null, false);
       } else {

--- a/src/passport/kakaoStrategy.ts
+++ b/src/passport/kakaoStrategy.ts
@@ -1,7 +1,7 @@
 import * as dotenv from 'dotenv';
 import * as passport from 'passport';
 import { Strategy } from 'passport-kakao';
-import User from '~/models/user';
+import db from '~/db';
 
 dotenv.config();
 
@@ -15,14 +15,18 @@ export function kakaoStrategy() {
       },
       async (accessToken, refreshToken, profile, done) => {
         try {
-          const [user] = await User.findOrCreate({
+          let user = await db.user.findUnique({
             where: { email: profile.id },
-            defaults: {
-              email: profile.id,
-              nickname: profile.displayName,
-              provider: profile.provider,
-            },
           });
+          if (!user) {
+            user = await db.user.create({
+              data: {
+                email: profile.id,
+                nickname: profile.displayName,
+                provider: profile.provider,
+              },
+            });
+          }
           return done(null, user);
         } catch (error) {
           return done(error);

--- a/src/passport/naverStrategy.ts
+++ b/src/passport/naverStrategy.ts
@@ -1,7 +1,7 @@
 import * as dotenv from 'dotenv';
 import * as passport from 'passport';
 import { Strategy } from 'passport-naver';
-import User from '~/models/user';
+import db from '~/db';
 
 dotenv.config();
 
@@ -15,14 +15,18 @@ export function naverStrategy() {
       },
       async (accessToken, refreshToken, profile, done) => {
         try {
-          const [user] = await User.findOrCreate({
+          let user = await db.user.findUnique({
             where: { email: profile.id },
-            defaults: {
-              email: profile.id,
-              nickname: profile.displayName,
-              provider: profile.provider,
-            },
           });
+          if (!user) {
+            user = await db.user.create({
+              data: {
+                email: profile.id,
+                nickname: profile.displayName,
+                provider: profile.provider,
+              },
+            });
+          }
           return done(null, user);
         } catch (error) {
           return done(error);

--- a/src/routes/teams/team.controller.ts
+++ b/src/routes/teams/team.controller.ts
@@ -1,28 +1,19 @@
+import { Team } from '@prisma/client';
 import * as express from 'express';
-import { db } from '~/models';
-import Team from '~/models/team';
+import db from '~/db';
 import { TypedExpressBody } from '~/typings/db';
 
 export const teamController = {
   async getMyTeams(req: express.Request, res: express.Response<Team[]>) {
     try {
       if (req.user) {
-        const teams = await req.user.getTeams();
-        const teamPreference = teams.reduce<{ [team: string]: number }>(
-          (prev, curr) => {
-            return {
-              ...prev,
-              [curr.team]: curr.UserTeams.preference,
-            };
-          },
-          {}
-        );
+        const result = await db.userTeams.findMany({
+          where: { userId: req.user.id },
+          select: { preference: true, team: true },
+          orderBy: { preference: 'asc' },
+        });
 
-        const teamsSortedByPreference = teams.sort(
-          (a, b) => teamPreference[a.team] - teamPreference[b.team]
-        );
-
-        res.json(teamsSortedByPreference);
+        res.json(result.map(team => team.team));
       }
     } catch (error) {
       console.error(error);
@@ -34,56 +25,20 @@ export const teamController = {
     res: express.Response
   ) {
     try {
-      if (req.user) {
-        const exTeams = await req.user.getTeams();
+      await db.user.update({
+        where: { id: req.user?.id },
+        data: {
+          myTeams: {
+            deleteMany: {},
+            create: req.body.teams.map((team, index) => ({
+              preference: index + 1,
+              team: { connect: { team } },
+            })),
+          },
+        },
+      });
 
-        // 새 팀 리스트에 없는 기존 팀만 따로 모아 관계 삭제
-        const removeNotExistExTeams = exTeams
-          .filter(
-            exTeam =>
-              req.body.teams.findIndex(newTeam => newTeam == exTeam.team) == -1
-          )
-          .map(exTeam => req.user?.removeTeam(exTeam));
-
-        // 새 팀 리스트에 있는 기존팀의 선호도가 변경된 경우, 선호도만 변경
-        const changeExTeamsPreference = exTeams
-          .filter(
-            exTeam =>
-              req.body.teams.findIndex(newTeam => newTeam == exTeam.team) != -1
-          )
-          .map(exTeam => {
-            const newTeamIndex = req.body.teams.findIndex(
-              newTeam => newTeam == exTeam.team
-            );
-
-            if (newTeamIndex + 1 == exTeam.UserTeams.preference) return;
-            return req.user?.addTeam(exTeam, {
-              through: { preference: newTeamIndex + 1 },
-            });
-          });
-
-        // 기존 팀 리스트에 없는 새 팀만 관계 설정 추가
-        const addNewTeamsPreference = req.body.teams.map(
-          async (newTeam, index) => {
-            const team = await db.Team.findOne({ where: { team: newTeam } });
-            if (team) {
-              const isMyTeam = await req.user?.hasTeam(team);
-              if (isMyTeam) return;
-
-              await req.user?.addTeam(team, {
-                through: { preference: index + 1 },
-              });
-            }
-          }
-        );
-
-        await Promise.all([
-          ...removeNotExistExTeams,
-          ...changeExTeamsPreference,
-          ...addNewTeamsPreference,
-        ]);
-        res.send();
-      }
+      res.send();
     } catch (error) {
       console.error(error);
     }

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -1,4 +1,4 @@
-import UserModel from '~/models/user';
+import { User as UserModel } from '@prisma/client';
 
 declare global {
   namespace Express {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "transpileOnly": true,
     "require": ["tsconfig-paths/register"]
   },
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*", "./prisma/**/*"]
 }


### PR DESCRIPTION
## What is this PR?

database orm 변경

### sequelize + typescript 문제점
sequelize 도 타입스크립트를 지원하지만, 관계 메서드나 프로퍼티 사용시에 직접 타이핑을 추가해서 사용해야 함.
문제는 이 타이핑이 개발자가 직접 정의하기 때문에, 정확한 타이핑인지 알 수 없음.
쿼리의 경우에도, `include` 로 모델에 관계를 추가할 때 타입이 처리되지 않음.
cli도 컴파일 처리된 js 파일을 이용해 seed, migration  등을 실행해야 함.

### prisma 변경한 이유
가장 큰 이유는 타입스크립트 지원이 sequelize 보다 너무 잘 되어 있었고,
스키마 작성, 마이그레이션 방식이 좀 더 간편했음.

sequelize 보다 프로퍼티가 직관적인 편이지만, 관계 쿼리의 경우, 오히려 코드 작성하기가 복잡하게 느껴지기도 함.
모델의 필드 타입에 대해서도 아쉬운 부분이 있었음.
`Date` 에 대해 `DateTime` 만 지원한다든지, 일부 제한된 부분이 존재함.
물론, 이를 대체할 수 있는 방법은 존재하므로, 일단 타입 지원이 강력한 prisma를 사용해보려고 함.

## Changes

- 모델 관계 변화
1. `Team`, `Stadium` 관계 삭제: 해당 관계를 이용한 로직이 현재 없고, 추후 기능이 필요할 때 다시 설정할 예정.
2. `TeamFans` → `UserTeams` 관계 모델명 변경

- 쿼리 로직 변경
1. `getMyTeams` 함수에서 직접 정렬을 시켰던 코드 삭제 후, 쿼리 내에서 정렬 처리
2. User - Team 관계도 전체 삭제 후, 전체를 다시 설정하는 방식으로 변경함. (이 부분은 어떤 방식이 효율적인 쿼리인지 파악하지 못함)
3. `getMyTickets` params `lastDate` 삭제. 

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] prisma로 변경한 쿼리 제대로 실행되는지 확인.

## Etc

보완해야 할 점
1. 비동기 로직에 대한 에러 핸들링.
2. 서비스 로직을 좀 더 구분하여 모듈화하기

seed 는 일단 초기 데이터를 추가해준다는 개념으로 코드를 작성했는데, 올바른지 잘 모르겠음.
